### PR TITLE
test against mocks by default, add prod-only endpoint tests, fix a couple api funcs

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,4 +2,5 @@ import Config
 
 config :jar, Jar.Config,
   sandbox: true,
-  debug: false
+  debug: false,
+  mock_http: true

--- a/lib/jar.ex
+++ b/lib/jar.ex
@@ -94,7 +94,7 @@ defmodule Jar do
   @doc """
   Validates an existing VAT identification number against VIES.
   """
-  def validate_vat_number(client, params \\ []), do: post(client, "/validation", params)
+  def validate_vat_number(client, params \\ []), do: get(client, "/validation", query: params)
 
   @doc """
   Lists minimum and average sales tax rates by region.

--- a/lib/jar/client.ex
+++ b/lib/jar/client.ex
@@ -25,7 +25,11 @@ defmodule Jar.Client do
       {Tesla.Middleware.Logger, debug: config.debug}
     ]
 
-    Tesla.client(middleware)
+    if config.mock_http do
+      Tesla.client(middleware, Tesla.Mock)
+    else
+      Tesla.client(middleware)
+    end
   end
 
   def new(config) do

--- a/lib/jar/config.ex
+++ b/lib/jar/config.ex
@@ -1,5 +1,5 @@
 defmodule Jar.Config do
-  defstruct version: "v2", sandbox: false, token: nil, debug: false
+  defstruct version: "v2", sandbox: false, token: nil, debug: false, mock_http: false
 
   @typedoc """
   Configuration for the API client.
@@ -14,7 +14,8 @@ defmodule Jar.Config do
           version: String.t(),
           sandbox: Boolean.t(),
           token: String.t(),
-          debug: Boolean.t()
+          debug: Boolean.t(),
+          mock_http: Boolean.t()
         }
 
   @doc """

--- a/test/prod_only_endpoints_test.exs
+++ b/test/prod_only_endpoints_test.exs
@@ -1,0 +1,86 @@
+defmodule ProdOnlyEndpointsTest do
+  @moduledoc """
+  These tests deal with API endpoints that are not available in the API sandbox.
+  They are only available in the live production API.
+
+  HTTP requests/responses are always mocked, even when `config :jar, Jar.Config, mock_http: false`.
+  """
+  use ExUnit.Case
+
+  import JarTest.Factory
+  import Tesla.Mock
+
+  setup_all do
+    [client: build(:always_mocked_production_client)]
+  end
+
+  setup do
+    mock(fn
+      %{method: :get, url: "https://api.taxjar.com/v2/customers"} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{customers: []}
+        }
+
+      %{method: :post, url: "https://api.taxjar.com/v2/addresses/validate"} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            addresses: [
+              %{
+                zip: "85297-2176",
+                street: "3301 S Greenfield Rd",
+                state: "AZ",
+                country: "US",
+                city: "Gilbert"
+              }
+            ]
+          }
+        }
+
+      %{method: :get, url: "https://api.taxjar.com/v2/validation"} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            validation: %{
+              valid: true,
+              exists: true,
+              vies_available: true,
+              vies_response: %{
+                country_code: "FR",
+                vat_number: "40303265045",
+                request_date: "2016-02-10",
+                valid: true,
+                name: "SA SODIMAS",
+                address: "11 RUE AMPERE\n26600 PONT DE L ISERE"
+              }
+            }
+          }
+        }
+    end)
+
+    :ok
+  end
+
+  test "`list_customers` returns customers", %{client: client} do
+    assert {:ok, %{customers: customers}} = Jar.list_customers(client)
+    assert is_list(customers)
+  end
+
+  test "`validate_address` returns address validation info", %{client: client} do
+    assert {:ok, %{addresses: addresses}} =
+             Jar.validate_address(client, build(:address_validation_params))
+
+    assert is_list(addresses)
+  end
+
+  test "`validate_vat_number` returns address validation info", %{client: client} do
+    assert {:ok, %{validation: validation}} =
+             Jar.validate_vat_number(client, build(:vat_validation_params))
+
+    assert %{valid: _, exists: _, vies_available: _, vies_response: vies_response} = validation
+
+    assert %{country_code: _, vat_number: _, request_date: _, valid: _, name: _, address: _} =
+             vies_response
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,6 +1,19 @@
 defmodule JarTest.Factory do
   use ExMachina
 
+  def sandbox_client_factory() do
+    Jar.Config.global()
+    |> Map.merge(%{sandbox: true})
+    |> Jar.configure()
+  end
+
+  def always_mocked_production_client_factory() do
+    Jar.Config.global()
+    # ALWAYS KEEP `mock_http: true` TO PREVENT LIVE API CALLS IN TESTS
+    |> Map.merge(%{sandbox: false, mock_http: true})
+    |> Jar.configure()
+  end
+
   def tax_calc_params_factory() do
     %{
       from_country: "US",
@@ -48,6 +61,22 @@ defmodule JarTest.Factory do
     %{
       from_transaction_date: "2015/05/01",
       to_transaction_date: "2015/05/31"
+    }
+  end
+
+  def address_validation_params_factory() do
+    %{
+      country: "US",
+      state: "AZ",
+      zip: "85297",
+      city: "Gilbert",
+      street: "3301 South Greenfield Rd"
+    }
+  end
+
+  def vat_validation_params_factory() do
+    %{
+      vat: "FR40303265045"
     }
   end
 end


### PR DESCRIPTION
fix #1 
fix #2 

* You can now switch between the default adapter and the mock adapter with `:mock_http`.
* Tests run with `mock_http: true` by default.
* Tests of endpoints that are only available in the live production API always run mocked, even when `mock_http: true`.
* (I tested the only-prod endpoints against the actual server and fixed any issues with those before switching their unit tests to always be mocked.)